### PR TITLE
Add 'Projects using this dataset' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ _Note: requires [jq](https://stedolan.github.io/jq/)_
 
 See also [Importing JSON into PostgreSQL using COPY](https://konbert.com/blog/import-json-into-postgres-using-copy)
 
+### Projects using this dataset
+
+- [WorkoutPartna Exercise Library](https://workoutpartna.com/exercises) — free browsable library of all 800+ exercises with photos & step-by-step instructions, used by an AI daily-coach app to illustrate generated workouts
+
 ### Browsable frontend
 
 <img src="./site/public/screenshot.png" alt="Screenshot of browsable frontend" width="500">


### PR DESCRIPTION
Hi! First off — thank you for maintaining this dataset; it's a fantastic resource.

This PR adds a small **Projects using this dataset** section to the README, seeded with one entry: [WorkoutPartna's free exercise library](https://workoutpartna.com/exercises), which serves all 800+ exercises as browsable how-to pages (photos + step-by-step instructions, no signup/paywall) and uses the dataset to illustrate AI-generated daily workouts. Attribution to this repo is shown on every page.

Figured a "used by" list might be useful social proof for the project and give future users examples to learn from — happy to adjust placement/wording or drop it entirely if you'd prefer. Thanks!